### PR TITLE
lightblue-client.properties fix

### DIFF
--- a/manifests/eap/module.pp
+++ b/manifests/eap/module.pp
@@ -55,7 +55,7 @@ class lightblue::eap::module (
         require => File['/usr/share/jbossas/modules/com/redhat/lightblue/main'],
     }
 
-    file { '/usr/share/jbossas/modules/com/redhat/lightblue/main/lightblue-cilent.properties':
+    file { '/usr/share/jbossas/modules/com/redhat/lightblue/main/lightblue-client.properties':
         mode    => '0644',
         owner   => 'jboss',
         group   => 'jboss',


### PR DESCRIPTION
Fixed typo in property file name that was fixed in code after last release.

WARNING: this property file fix in java code is not released yet... only fixed in 1.2.0-SNAPSHOT
