### PR TITLE
Inherit from lightblue::eap in client class

### DIFF
--- a/manifests/eap/client.pp
+++ b/manifests/eap/client.pp
@@ -72,7 +72,10 @@ define lightblue::eap::client (
 {
     $module_path = "/usr/share/jbossas/modules/com/redhat/lightblue/client/${name}/main"
 
-    $module_dirs = ['/usr/share/jbossas/modules/com/redhat/lightblue/client',
+    $module_dirs = ['/usr/share/jbossas/modules/com',
+        '/usr/share/jbossas/modules/com/redhat',
+        '/usr/share/jbossas/modules/com/redhat/lightblue',
+        '/usr/share/jbossas/modules/com/redhat/lightblue/client',
         "/usr/share/jbossas/modules/com/redhat/lightblue/client/${name}", 
         $module_path]
 


### PR DESCRIPTION
I think this makes more sense / is more consistent.
