### PR TITLE
Rename parameters to avoid confusion with app URIs

### DIFF
--- a/manifests/eap/client.pp
+++ b/manifests/eap/client.pp
@@ -48,12 +48,12 @@
 # === Examples
 #
 #    lightblue::eap::client { 'myapp' :
-#        data_service_uri           => 'https://mylightblue.mycompany.com/rest/data',
-#        metadata_service_uri       => 'https://mylightblue.mycompany.com/rest/metadata',
-#        use_cert_auth      => true,
-#        auth_cert_source   => 'puppet:///path/to/your/lb-myapp.pkcs12',
-#        auth_cert_password => hiera('myapp::lightblue::pass'),
-#        ssl_ca_source      => 'puppet:///path/to/your/cacert.pem',
+#        data_service_uri     => 'https://mylightblue.mycompany.com/rest/data',
+#        metadata_service_uri => 'https://mylightblue.mycompany.com/rest/metadata',
+#        use_cert_auth        => true,
+#        auth_cert_source     => 'puppet:///path/to/your/lb-myapp.pkcs12',
+#        auth_cert_password   => hiera('myapp::lightblue::pass'),
+#        ssl_ca_source        => 'puppet:///path/to/your/cacert.pem',
 #    }
 #
 define lightblue::eap::client (


### PR DESCRIPTION
...to be clear that these are URIs for the services, not the management applications.
