### PR TITLE
Fix various syntax issues in lightblue config rdbms templates

### DIFF
--- a/templates/properties/datasources.json.erb
+++ b/templates/properties/datasources.json.erb
@@ -101,31 +101,28 @@
 <% if rdbms_servers_cfg.kind_of?(Array) -%>   
    ,
     "rdbms" : {
-    "type" : "com.redhat.lightblue.config.rdbms.RDBMSDataSourceConfiguration",
-    "metadataDataStoreParser" : "com.redhat.lightblue.metadata.rdbms.impl.RDBMSDataStoreParser",
-    <% if database -%>
-    "database" : "<%=rdbms_servers_cfg.database%>",
-    <% end -%>
-    <% if rdbms_servers_cfg.connections.kind_of?(Array) -%>
-    "connections" : [
-    <%
-    i = rdbms_servers_cfg.connections.length
-    rdbms_servers_cfg.connections.each do |connection|
-    -%>
-    {
-       "datasourceName" : "<%=connection['datasourceName']%>",
-       "JNDI" : "<%=connection['JNDI']%>"
+        "type" : "com.redhat.lightblue.config.rdbms.RDBMSDataSourceConfiguration",
+        "metadataDataStoreParser" : "com.redhat.lightblue.metadata.rdbms.impl.RDBMSDataStoreParser",
+        "database" : "rdbms",
+        "connections" : [
+        <%
+        i = rdbms_servers_cfg.length
+        rdbms_servers_cfg.each do |connection|
+        -%>
+        {
+          "datasourceName" : "<%=connection['datasourceName']%>",
+          "JNDI" : "<%=connection['JNDI']%>"
+        }
+        <% if i > 1 then -%>
+        ,
+        <%
+        end 
+        i = i - 1
+        -%>
+        <% end -%>
+        ]
+<% end -%>  
     }
-    <% if i > 1 then -%>
-    ,
-    <%
-      end 
-      i = i - 1
-    -%>
-     <% end -%>
-     ]
-   <% end -%>
-   }
-<% end -%>   
+   
    
 }

--- a/templates/properties/lightblue-crud.json.erb
+++ b/templates/properties/lightblue-crud.json.erb
@@ -6,12 +6,13 @@
       }
       
       <% if additional_backend_controllers != '' && additional_backend_controllers.kind_of?(Array) -%>   
-        additional_backend_controllers.each do |controller|
+        <% additional_backend_controllers.each do |controller| -%>
         ,   
         {
        "backend" : "<%=controller['backend']%>",
        "controllerFactory" : "<%=controller['controllerFactory']%>"
         }
+        <% end -%>
       <% end -%> 
    ]
 }

--- a/templates/properties/lightblue-metadata.json.erb
+++ b/templates/properties/lightblue-metadata.json.erb
@@ -22,7 +22,7 @@
      ],
 <% end -%>
 <% if backend_parsers != '' && backend_parsers.kind_of?(Array) -%>
-    "backend_parsers": [
+    "backendParsers" : [
         <%
         j = backend_parsers.length
         backend_parsers.each do |backend_parser|
@@ -42,7 +42,7 @@
      ],
 <% end -%>
 <% if property_parsers != '' && property_parsers.kind_of?(Array) -%>
-    "property_parsers": [
+    "propertyParsers" : [
         <%
         k = property_parsers.length
         property_parsers.each do |property_parser|


### PR DESCRIPTION
This PR fixes a handful of syntax-related issues I encountered when actually trying to use these puppet templates