### PR TITLE
fixes #78 - removes the run for ruby 2.1.0 and puppet 3.4.0 as that is n...

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,10 @@ env:
     - PUPPET_VERSION="~> 3.5.0"
     - PUPPET_VERSION="~> 3.6.0"
     - PUPPET_VERSION="~> 3.7.0"
+matrix:
+    exclude:
+        - rvm: 2.1.0
+          env: PUPPET_VERSION="~> 3.4.0"
 notifications:
   email: false
   irc:


### PR DESCRIPTION
...ot a supported combination anyway