### PR TITLE
add ability for puppet module to use physical files

### DIFF
--- a/manifests/client/configure.pp
+++ b/manifests/client/configure.pp
@@ -13,6 +13,10 @@
 # $lbclient_cert_file_path - cert file path. Required only if $lbclient_use_cert_auth == true.
 # $lbclient_cert_password  - cert password. Required only if $lbclient_use_cert_auth == true.
 # $lbclient_cert_alias     - cert alias. Required only if $lbclient_use_cert_auth == true.
+# $use_physical_file       - It is generally assumed that the cert and ca files will bundled in the application binary,
+#                            however toggling to true provides the ability for the files to be physically located
+#                            on the file system.
+#                            (defaults to false)
 #
 # === Variables
 #
@@ -34,6 +38,7 @@ define lightblue::client::configure (
     $lbclient_cert_file_path = undef,
     $lbclient_cert_password = undef,
     $lbclient_cert_alias = undef,
+    $use_physical_file = false,
 ) {
 
     file { $title:

--- a/manifests/client/configure.pp
+++ b/manifests/client/configure.pp
@@ -4,19 +4,19 @@
 #
 # === Parameters
 #
-# $owner                   - The user to whom the file should belong. Defaults to 'root'.
-# $group                   - The group to whom the file should belong. Defaults to 'root'.
-# $lbclient_metadata_uri   - metadata uri (required)
-# $lbclient_data_uri       - data uri (required)
-# $lbclient_use_cert_auth  - true/false indicating if cert authentication is required. Defaults to false.
-# $lbclient_ca_file_path   - ca file path. Required only if $lbclient_use_cert_auth == true.
-# $lbclient_cert_file_path - cert file path. Required only if $lbclient_use_cert_auth == true.
-# $lbclient_cert_password  - cert password. Required only if $lbclient_use_cert_auth == true.
-# $lbclient_cert_alias     - cert alias. Required only if $lbclient_use_cert_auth == true.
-# $use_physical_file       - It is generally assumed that the cert and ca files will bundled in the application binary,
-#                            however toggling to true provides the ability for the files to be physically located
-#                            on the file system.
-#                            (defaults to false)
+# $owner                      - The user to whom the file should belong. Defaults to 'root'.
+# $group                      - The group to whom the file should belong. Defaults to 'root'.
+# $lbclient_metadata_uri      - metadata uri (required)
+# $lbclient_data_uri          - data uri (required)
+# $lbclient_use_cert_auth     - true/false indicating if cert authentication is required. Defaults to false.
+# $lbclient_ca_file_path      - ca file path. Required only if $lbclient_use_cert_auth == true.
+# $lbclient_cert_file_path    - cert file path. Required only if $lbclient_use_cert_auth == true.
+# $lbclient_cert_password     - cert password. Required only if $lbclient_use_cert_auth == true.
+# $lbclient_cert_alias        - cert alias. Required only if $lbclient_use_cert_auth == true.
+# $lbclient_use_physical_file - It is generally assumed that the cert and ca files will bundled in the application binary,
+#                               however toggling to true provides the ability for the files to be physically located
+#                               on the file system.
+#                               (defaults to false)
 #
 # === Variables
 #
@@ -38,7 +38,7 @@ define lightblue::client::configure (
     $lbclient_cert_file_path = undef,
     $lbclient_cert_password = undef,
     $lbclient_cert_alias = undef,
-    $use_physical_file = false,
+    $lbclient_use_physical_file = false,
 ) {
 
     file { $title:

--- a/spec/defines/lightblue/client/configure_spec.rb
+++ b/spec/defines/lightblue/client/configure_spec.rb
@@ -35,32 +35,60 @@ describe 'lightblue::client::configure' do
     password = 'secret'
     cert_alias = 'redleader'
     
-    let :params do
-      {
-        :lbclient_metadata_uri => metadata_uri,
-        :lbclient_data_uri => data_uri,
-        :lbclient_use_cert_auth => true,
-        :lbclient_ca_file_path => ca_file_path,
-        :lbclient_cert_file_path => cert_file_path,
-        :lbclient_cert_password => password,
-        :lbclient_cert_alias => cert_alias
-      }
+    describe 'and use_physical_file=false' do
+      let :params do
+        {
+          :lbclient_metadata_uri => metadata_uri,
+          :lbclient_data_uri => data_uri,
+          :lbclient_use_cert_auth => true,
+          :lbclient_ca_file_path => ca_file_path,
+          :lbclient_cert_file_path => cert_file_path,
+          :lbclient_cert_password => password,
+          :lbclient_cert_alias => cert_alias
+        }
+      end
+      
+      it do 
+        should contain_file(config_file).with({
+          'ensure' => 'file',
+          'owner'  => 'root',
+          'group'  => 'root',
+          'mode'   => '0644',
+        }) \
+          .with_content(/^metadataServiceURI=#{metadata_uri}$/) \
+          .with_content(/^dataServiceURI=#{data_uri}/) \
+          .with_content(/^useCertAuth=true/) \
+          .with_content(/^caFilePath=#{ca_file_path}/) \
+          .with_content(/^certFilePath=#{cert_file_path}/) \
+          .with_content(/^certPassword=#{password}/) \
+          .with_content(/^certAlias=#{cert_alias}/)
+      end
     end
     
-    it do 
-      should contain_file(config_file).with({
-        'ensure' => 'file',
-        'owner'  => 'root',
-        'group'  => 'root',
-        'mode'   => '0644',
-      }) \
-        .with_content(/^metadataServiceURI=#{metadata_uri}$/) \
-        .with_content(/^dataServiceURI=#{data_uri}/) \
-        .with_content(/^useCertAuth=true/) \
-        .with_content(/^caFilePath=#{ca_file_path}/) \
-        .with_content(/^certFilePath=#{cert_file_path}/) \
-        .with_content(/^certPassword=#{password}/) \
-        .with_content(/^certAlias=#{cert_alias}/)
+    describe 'and use_physical_file=true' do
+      let :params do
+        {
+          :lbclient_metadata_uri => metadata_uri,
+          :lbclient_data_uri => data_uri,
+          :lbclient_use_cert_auth => true,
+          :lbclient_ca_file_path => ca_file_path,
+          :lbclient_cert_file_path => cert_file_path,
+          :lbclient_cert_password => password,
+          :lbclient_cert_alias => cert_alias,
+          :use_physical_file => true,
+        }
+      end
+      
+      it do 
+        should contain_file(config_file).with({
+          'ensure' => 'file',
+          'owner'  => 'root',
+          'group'  => 'root',
+          'mode'   => '0644',
+        }) \
+          .with_content(/^caFilePath=file:\/\/#{ca_file_path}/) \
+          .with_content(/^certFilePath=file:\/\/#{cert_file_path}/)
+      end
     end
   end
   

--- a/spec/defines/lightblue/client/configure_spec.rb
+++ b/spec/defines/lightblue/client/configure_spec.rb
@@ -35,7 +35,7 @@ describe 'lightblue::client::configure' do
     password = 'secret'
     cert_alias = 'redleader'
     
-    describe 'and use_physical_file=false' do
+    describe 'and lbclient_use_physical_file=false' do
       let :params do
         {
           :lbclient_metadata_uri => metadata_uri,
@@ -65,7 +65,7 @@ describe 'lightblue::client::configure' do
       end
     end
     
-    describe 'and use_physical_file=true' do
+    describe 'and lbclient_use_physical_file=true' do
       let :params do
         {
           :lbclient_metadata_uri => metadata_uri,
@@ -75,7 +75,7 @@ describe 'lightblue::client::configure' do
           :lbclient_cert_file_path => cert_file_path,
           :lbclient_cert_password => password,
           :lbclient_cert_alias => cert_alias,
-          :use_physical_file => true,
+          :lbclient_use_physical_file => true,
         }
       end
       

--- a/templates/client/lightblue-client.properties.erb
+++ b/templates/client/lightblue-client.properties.erb
@@ -2,8 +2,8 @@ metadataServiceURI=<%= @lbclient_metadata_uri %>
 dataServiceURI=<%= @lbclient_data_uri %>
 useCertAuth=<%= @lbclient_use_cert_auth %>
 <% if(@lbclient_use_cert_auth == true) -%>
-caFilePath=<% if(@use_physical_file == true) %>file://<%end%><%= @lbclient_ca_file_path %>
-certFilePath=<% if(@use_physical_file == true) %>file://<%end%><%= @lbclient_cert_file_path %>
+caFilePath=<% if(@lbclient_use_physical_file == true) %>file://<%end%><%= @lbclient_ca_file_path %>
+certFilePath=<% if(@lbclient_use_physical_file == true) %>file://<%end%><%= @lbclient_cert_file_path %>
 certPassword=<%= @lbclient_cert_password %>
 certAlias=<%= @lbclient_cert_alias %>
 <% end -%>

--- a/templates/client/lightblue-client.properties.erb
+++ b/templates/client/lightblue-client.properties.erb
@@ -2,8 +2,8 @@ metadataServiceURI=<%= @lbclient_metadata_uri %>
 dataServiceURI=<%= @lbclient_data_uri %>
 useCertAuth=<%= @lbclient_use_cert_auth %>
 <% if(@lbclient_use_cert_auth == true) -%>
-caFilePath=<%= @lbclient_ca_file_path %>
-certFilePath=<%= @lbclient_cert_file_path %>
+caFilePath=<% if(@use_physical_file == true) %>file://<%end%><%= @lbclient_ca_file_path %>
+certFilePath=<% if(@use_physical_file == true) %>file://<%end%><%= @lbclient_cert_file_path %>
 certPassword=<%= @lbclient_cert_password %>
 certAlias=<%= @lbclient_cert_alias %>
 <% end -%>


### PR DESCRIPTION
This is a follow up to https://github.com/lightblue-platform/lightblue-client/pull/52

A new option is available to inform puppet that the cert and ca files are physically located on the file system as opposed to in the class path.