### PR TITLE
Fixing eap module path creation and some syntax quirks

### DIFF
--- a/manifests/application/migrator/daemon.pp
+++ b/manifests/application/migrator/daemon.pp
@@ -42,16 +42,16 @@ class lightblue::application::migrator::daemon (
     $jsvc_version = 'latest',
     $owner = 'root',
     $group = 'root',
-    $service_name = undef,
     $jsvc_exec = '$(which jsvc)',
     $java_home = undef,
-    $service_out_logfile = undef,
-    $service_err_logfile = undef,
     $lib_dir = undef,
-    $jar_path = undef,
-    $mainClass = undef,
     $arguments = {},
     $jvmOptions = {},
+    $service_name,
+    $service_out_logfile,
+    $service_err_logfile,
+    $jar_path,
+    $mainClass,
 ) {
     case $::osfamily {
         'RedHat', 'Linux': {

--- a/manifests/application/migrator/daemon.pp
+++ b/manifests/application/migrator/daemon.pp
@@ -41,14 +41,14 @@ class lightblue::application::migrator::daemon (
     $jsvc_version = 'latest',
     $owner = 'root',
     $group = 'root',
-    $service_name,
+    $service_name = undef,
     $jsvc_exec = '$(which jsvc)',
     $java_home = undef,
-    $service_out_logfile,
-    $service_err_logfile,
+    $service_out_logfile = undef,
+    $service_err_logfile = undef,
     $lib_dir = undef,
-    $jar_path,
-    $mainClass,
+    $jar_path = undef,
+    $mainClass = undef,
     $arguments = {}
 ) {
     case $::osfamily {

--- a/manifests/eap/client.pp
+++ b/manifests/eap/client.pp
@@ -69,7 +69,7 @@ define lightblue::eap::client (
     $ssl_ca_file_path="cacert.pem"
 )
 {
-    include lightblue::eap::client::modulepath
+    require lightblue::eap::client::modulepath
 
     $module_path = "/usr/share/jbossas/modules/com/redhat/lightblue/client/${name}/main"
 
@@ -83,7 +83,6 @@ define lightblue::eap::client (
         owner    => 'jboss',
         group    => 'jboss',
         mode     => '0755',
-        require  => Class['lightblue::eap::client::modulepath']
     }
 
     file { "${module_path}/module.xml":

--- a/manifests/eap/client.pp
+++ b/manifests/eap/client.pp
@@ -106,7 +106,7 @@ define lightblue::eap::client (
     }
 
     if $use_cert_auth {
-        if defined('$auth_cert_content') {
+        if $auth_cert_content {
             file { "${module_path}/${auth_cert_file_path}":
                 mode    => '0644',
                 owner   => 'jboss',
@@ -116,7 +116,7 @@ define lightblue::eap::client (
                 notify  => Service['jbossas'],
                 require => File[$module_dirs],
             }
-        } elsif defined('$auth_cert_source') {
+        } elsif $auth_cert_source {
             file { "${module_path}/${auth_cert_file_path}":
                 mode    => '0644',
                 owner   => 'jboss',

--- a/manifests/eap/client.pp
+++ b/manifests/eap/client.pp
@@ -69,21 +69,21 @@ define lightblue::eap::client (
     $ssl_ca_file_path="cacert.pem"
 )
 {
+    include lightblue::eap::client::modulepath
+
     $module_path = "/usr/share/jbossas/modules/com/redhat/lightblue/client/${name}/main"
 
-    $module_dirs = ['/usr/share/jbossas/modules/com',
-        '/usr/share/jbossas/modules/com/redhat',
-        '/usr/share/jbossas/modules/com/redhat/lightblue',
-        '/usr/share/jbossas/modules/com/redhat/lightblue/client',
-        "/usr/share/jbossas/modules/com/redhat/lightblue/client/${name}",
-        $module_path]
+    $module_dirs = ["/usr/share/jbossas/modules/com/redhat/lightblue/client/${name}", $module_path]
 
+    # Setup the properties directory
+    # mkdir -p equivalent in puppet is crazy :/
     # Setup the module directory
     file { $module_dirs :
         ensure   => 'directory',
         owner    => 'jboss',
         group    => 'jboss',
         mode     => '0755',
+        require  => Class['lightblue::eap::client::modulepath']
     }
 
     file { "${module_path}/module.xml":

--- a/manifests/eap/client/modulepath.pp
+++ b/manifests/eap/client/modulepath.pp
@@ -1,7 +1,7 @@
 # Setting up common module path for lightblue::eap::client resource
 class lightblue::eap::client::modulepath {
 
-    # Pretty sure many of those paths will conflicts with something else...
+    # Pretty sure many of those paths will conflict with something else...
     # Perhaps better use mkdir -p ?
     $module_base = [ '/usr/share/jbossas/modules/com',
         '/usr/share/jbossas/modules/com/redhat',

--- a/manifests/eap/client/modulepath.pp
+++ b/manifests/eap/client/modulepath.pp
@@ -1,0 +1,18 @@
+# Setting up common module path for lightblue::eap::client resource
+class lightblue::eap::client::modulepath {
+
+    # Pretty sure many of those paths will conflicts with something else...
+    # Perhaps better use mkdir -p ?
+    $module_base = [ '/usr/share/jbossas/modules/com',
+        '/usr/share/jbossas/modules/com/redhat',
+        '/usr/share/jbossas/modules/com/redhat/lightblue',
+        '/usr/share/jbossas/modules/com/redhat/lightblue/client']
+
+    file { $module_base :
+        ensure   => 'directory',
+        owner    => 'jboss',
+        group    => 'jboss',
+        mode     => '0755',
+    }
+
+}


### PR DESCRIPTION
The first 2 fixes (commits 'Making puppet lint happy' and 'Fix check if var defined') are probably related to the puppet version we're using (2.7). Perhaps this works on 3.x.

The last fix ('Fix creating module paths') is required to be able to create more than client configuration on a single host.