### PR TITLE
ensure log file exists

### DIFF
--- a/manifests/application/migrator.pp
+++ b/manifests/application/migrator.pp
@@ -265,6 +265,12 @@ class lightblue::application::migrator (
       }
     }
 
+    file { $service_log_file:
+      ensure  => 'file',
+      owner   => $service_owner,
+      group   => $service_group,
+      mode    => '0744',
+    } ->
     class { 'lightblue::application::migrator::daemon':
       jsvc_version        => $jsvc_version,
       owner               => $service_owner,


### PR DESCRIPTION
Small change to ensure the migrator log file is readable by all users.