### PR TITLE
Enable graphite/statsd for migrator instances via puppet

### DIFF
--- a/manifests/application/migrator.pp
+++ b/manifests/application/migrator.pp
@@ -113,6 +113,8 @@ class lightblue::application::migrator (
 ){
     require lightblue::yumrepo::lightblue
     require lightblue::java
+    require lightblue::service::plugin::graphite
+    require lightblue::service::plugin::statsd
 
     $migrator_service_name = 'migrator-service'
     $migrator_package_name = 'lightblue-migrator-consistency-checker'


### PR DESCRIPTION
Related too: https://github.com/lightblue-platform/lightblue-migrator/pull/95