### PR TITLE
Fix #72: Reviewed usage of 'inherits'

### DIFF
--- a/manifests/eap/module.pp
+++ b/manifests/eap/module.pp
@@ -90,6 +90,7 @@
 #
 # === Examples
 #
+include lightblue::eap
 class lightblue::eap::module (
     $mongo_auth_mechanism,
     $mongo_auth_username,
@@ -119,7 +120,6 @@ class lightblue::eap::module (
     $data_cors_config=undef,
     $metadata_cors_config=undef,
 )
-inherits lightblue::eap
 {
     $directory = '/usr/share/jbossas/modules/com/redhat/lightblue/main'
 

--- a/manifests/eap/module.pp
+++ b/manifests/eap/module.pp
@@ -90,7 +90,6 @@
 #
 # === Examples
 #
-include lightblue::eap
 class lightblue::eap::module (
     $mongo_auth_mechanism,
     $mongo_auth_username,
@@ -121,6 +120,7 @@ class lightblue::eap::module (
     $metadata_cors_config=undef,
 )
 {
+    include lightblue::eap
     $directory = '/usr/share/jbossas/modules/com/redhat/lightblue/main'
 
     # Setup the properties directory


### PR DESCRIPTION
From issue https://github.com/lightblue-platform/lightblue-puppet/issues/72 . 

The recommendation from PuppetLab ( https://docs.puppetlabs.com/puppet/latest/reference/lang_classes.html#aside-when-to-inherit ) is to avoid the inheritance as is can drastically increase the complexity. It is only recommended in cases such as param classes. Otherwise it recommends to use 'include' ( https://docs.puppetlabs.com/puppet/latest/reference/lang_classes.html#using-include ) which is similar to 'require' ( https://docs.puppetlabs.com/puppet/latest/reference/lang_classes.html#using-require ), but 'require' could have cyclic dependency and 'include' doesn't have this problem. Only a file was changed as the other ones  (manifests/service/data.pp, manifests/service/metadata.pp, manifests/application/datamgmt.pp, manifests/application/metadatamgmt.pp) seem to be using   'inherits' as expected.  