### PR TITLE
Fix that java.pp class

### DIFF
--- a/manifests/java.pp
+++ b/manifests/java.pp
@@ -29,13 +29,24 @@ class lightblue::java ($java_version = '1.7.0', $java_distribution = 'openjdk', 
   $jvm_export = "/usr/lib/jvm-exports/"
   $jre_location = "${jvm_dir}jre-${java_version_distribution}"
   $alternative_priority = 9000000
-  $java_package_jre_install = $java_specific_version ? {
-    undef   => "latest",
-    default => "java-${java_version}-${java_distribution}-${java_specific_version}.${::architecture}"
+
+  if($java_specific_version == "latest" or $java_specific_version == "installed"){
+    $java_package_jre_install = $java_specific_version
   }
-  $java_package_sdk_install = $java_specific_version ? {
-    undef   => "latest",
-    default => "java-${java_version}-${java_distribution}-devel-${java_specific_version}.${::architecture}"
+  else{
+    $java_package_jre_install = $java_specific_version ? {
+      undef       => "latest",
+      default     => "${java_specific_version}.${::architecture}"
+    }
+  }
+  if($java_specific_version == "latest" or $java_specific_version == "installed"){
+    $java_package_sdk_install = $java_specific_version
+  }
+  else{
+    $java_package_sdk_install = $java_specific_version ? {
+      undef   => "latest",
+      default => "${java_specific_version}.${::architecture}"
+    }
   }
 
   package { 'java':

--- a/manifests/java.pp
+++ b/manifests/java.pp
@@ -31,32 +31,23 @@ class lightblue::java ($java_version = '1.7.0', $java_distribution = 'openjdk', 
   $alternative_priority = 9000000
 
   if($java_specific_version == "latest" or $java_specific_version == "installed"){
-    $java_package_jre_install = $java_specific_version
+    $java_package_version = $java_specific_version
   }
   else{
-    $java_package_jre_install = $java_specific_version ? {
+    $java_package_version = $java_specific_version ? {
       undef       => "latest",
       default     => "${java_specific_version}"
     }
   }
-  if($java_specific_version == "latest" or $java_specific_version == "installed"){
-    $java_package_sdk_install = $java_specific_version
-  }
-  else{
-    $java_package_sdk_install = $java_specific_version ? {
-      undef   => "latest",
-      default => "${java_specific_version}"
-    }
-  }
 
   package { 'java':
-    ensure => $java_package_jre_install,
+    ensure => $java_package_version,
     name   => "java-${java_version}-${java_distribution}",
     alias  =>"java",
   }
   ->
   package { 'java-devel':
-    ensure => $java_package_sdk_install,
+    ensure => $java_package_version,
     name   => "java-${java_version}-${java_distribution}-devel",
     alias  =>"java-devel",
   }

--- a/manifests/java.pp
+++ b/manifests/java.pp
@@ -30,23 +30,23 @@ class lightblue::java ($java_version = '1.7.0', $java_distribution = 'openjdk', 
   $jre_location = "${jvm_dir}jre-${java_version_distribution}"
   $alternative_priority = 9000000
   $java_package_jre_install = $java_specific_version ? {
-    undef   => "java-${java_version}-${java_distribution}",
+    undef   => "latest",
     default => "java-${java_version}-${java_distribution}-${java_specific_version}.${::architecture}"
   }
   $java_package_sdk_install = $java_specific_version ? {
-    undef   => "java-${java_version}-${java_distribution}-devel",
+    undef   => "latest",
     default => "java-${java_version}-${java_distribution}-devel-${java_specific_version}.${::architecture}"
   }
 
   package { 'java':
     ensure => $java_package_jre_install,
-    name   => "${java_package_jre_install}",
+    name   => "java-${java_version}-${java_distribution}",
     alias  =>"java",
   }
   ->
   package { 'java-devel':
     ensure => $java_package_sdk_install,
-    name   => "${java_package_sdk_install}",
+    name   => "java-${java_version}-${java_distribution}-devel",
     alias  =>"java-devel",
   }
   ->

--- a/manifests/java.pp
+++ b/manifests/java.pp
@@ -36,7 +36,7 @@ class lightblue::java ($java_version = '1.7.0', $java_distribution = 'openjdk', 
   else{
     $java_package_jre_install = $java_specific_version ? {
       undef       => "latest",
-      default     => "${java_specific_version}.${::architecture}"
+      default     => "${java_specific_version}"
     }
   }
   if($java_specific_version == "latest" or $java_specific_version == "installed"){
@@ -45,7 +45,7 @@ class lightblue::java ($java_version = '1.7.0', $java_distribution = 'openjdk', 
   else{
     $java_package_sdk_install = $java_specific_version ? {
       undef   => "latest",
-      default => "${java_specific_version}.${::architecture}"
+      default => "${java_specific_version}"
     }
   }
 

--- a/spec/classes/lightblue/java_spec.rb
+++ b/spec/classes/lightblue/java_spec.rb
@@ -79,13 +79,13 @@ describe 'lightblue::java' do
     it do
       should contain_package('java').with(
         {
-          :ensure =>'1.8.0.40-24.b25.fc21.x86_64',
+          :ensure =>'1.8.0.40-24.b25.fc21',
           :name => 'java-1.8.0-openjdk',
         }
       )
       should contain_package('java-devel').with(
         {
-          :ensure =>'1.8.0.40-24.b25.fc21.x86_64',
+          :ensure =>'1.8.0.40-24.b25.fc21',
           :name => 'java-1.8.0-openjdk-devel',
         }
       )
@@ -200,13 +200,13 @@ describe 'lightblue::java' do
     it do
       should contain_package('java').with(
         {
-          :ensure => '1.8.0.40-24.b25.fc21.x86_64',
+          :ensure => '1.8.0.40-24.b25.fc21',
           :name => 'java-1.8.0-openjdk',
         }
       )
       should contain_package('java-devel').with(
         {
-          :ensure =>'1.8.0.40-24.b25.fc21.x86_64',
+          :ensure =>'1.8.0.40-24.b25.fc21',
           :name => 'java-1.8.0-openjdk-devel',
         }
       )

--- a/spec/classes/lightblue/java_spec.rb
+++ b/spec/classes/lightblue/java_spec.rb
@@ -79,13 +79,13 @@ describe 'lightblue::java' do
     it do
       should contain_package('java').with(
         {
-          :ensure =>'java-1.8.0-openjdk-1.8.0.40-24.b25.fc21.x86_64',
+          :ensure =>'1.8.0.40-24.b25.fc21.x86_64',
           :name => 'java-1.8.0-openjdk',
         }
       )
       should contain_package('java-devel').with(
         {
-          :ensure =>'java-1.8.0-openjdk-devel-1.8.0.40-24.b25.fc21.x86_64',
+          :ensure =>'1.8.0.40-24.b25.fc21.x86_64',
           :name => 'java-1.8.0-openjdk-devel',
         }
       )
@@ -148,6 +148,37 @@ describe 'lightblue::java' do
       )
     end
   end
+  
+  context 'rhel7 x64 installed' do
+    let :facts do
+      {
+        :osfamily => 'RedHat',
+        :architecture => 'x86_64',
+        :operatingsystemrelease => '7.0'
+      }
+    end
+    
+    let :params do
+      {
+        :java_specific_version => "installed"
+      }
+    end
+
+    it do
+      should contain_package('java').with(
+        {
+          :ensure => 'installed',
+          :name => 'java-1.7.0-openjdk',
+        }
+      )
+      should contain_package('java-devel').with(
+        {
+          :ensure => 'installed',
+          :name => 'java-1.7.0-openjdk-devel',
+        }
+      )
+    end
+  end
 
   context 'rhel7 x64 java specific minor version' do
     let :facts do
@@ -169,13 +200,13 @@ describe 'lightblue::java' do
     it do
       should contain_package('java').with(
         {
-          :ensure => 'java-1.8.0-openjdk-1.8.0.40-24.b25.fc21.x86_64',
+          :ensure => '1.8.0.40-24.b25.fc21.x86_64',
           :name => 'java-1.8.0-openjdk',
         }
       )
       should contain_package('java-devel').with(
         {
-          :ensure =>'java-1.8.0-openjdk-devel-1.8.0.40-24.b25.fc21.x86_64',
+          :ensure =>'1.8.0.40-24.b25.fc21.x86_64',
           :name => 'java-1.8.0-openjdk-devel',
         }
       )

--- a/spec/classes/lightblue/java_spec.rb
+++ b/spec/classes/lightblue/java_spec.rb
@@ -14,12 +14,12 @@ describe 'lightblue::java' do
     it do
       should contain_package('java').with(
         {
-          :ensure => 'java-1.7.0-openjdk'
+          :ensure => 'latest'
         }
       )
       should contain_package('java-devel').with(
         {
-          :ensure => 'java-1.7.0-openjdk-devel'
+          :ensure => 'latest'
         }
       )
     end
@@ -44,12 +44,12 @@ describe 'lightblue::java' do
     it do
       should contain_package('java').with(
         {
-          :ensure => 'java-1.8.0-openjdk'
+          :ensure => 'latest'
         }
       )
       should contain_package('java-devel').with(
         {
-          :ensure => 'java-1.8.0-openjdk-devel'
+          :ensure => 'latest'
         }
       )
     end
@@ -98,12 +98,12 @@ describe 'lightblue::java' do
     it do
       should contain_package('java').with(
         {
-          :ensure => 'java-1.7.0-openjdk'
+          :ensure => 'latest'
         }
       )
       should contain_package('java-devel').with(
         {
-          :ensure => 'java-1.7.0-openjdk-devel'
+          :ensure => 'latest'
         }
       )
     end
@@ -128,12 +128,12 @@ describe 'lightblue::java' do
     it do
       should contain_package('java').with(
         {
-          :ensure => 'java-1.8.0-openjdk'
+          :ensure => 'latest'
         }
       )
       should contain_package('java-devel').with(
         {
-          :ensure => 'java-1.8.0-openjdk-devel'
+          :ensure => 'latest'
         }
       )
     end

--- a/spec/classes/lightblue/java_spec.rb
+++ b/spec/classes/lightblue/java_spec.rb
@@ -14,12 +14,14 @@ describe 'lightblue::java' do
     it do
       should contain_package('java').with(
         {
-          :ensure => 'latest'
+          :ensure => 'latest',
+          :name => 'java-1.7.0-openjdk',
         }
       )
       should contain_package('java-devel').with(
         {
-          :ensure => 'latest'
+          :ensure => 'latest',
+          :name => 'java-1.7.0-openjdk-devel',
         }
       )
     end
@@ -44,12 +46,14 @@ describe 'lightblue::java' do
     it do
       should contain_package('java').with(
         {
-          :ensure => 'latest'
+          :ensure => 'latest',
+          :name => 'java-1.8.0-openjdk',
         }
       )
       should contain_package('java-devel').with(
         {
-          :ensure => 'latest'
+          :ensure => 'latest',
+          :name => 'java-1.8.0-openjdk-devel',
         }
       )
     end
@@ -75,12 +79,14 @@ describe 'lightblue::java' do
     it do
       should contain_package('java').with(
         {
-          :ensure =>'java-1.8.0-openjdk-1.8.0.40-24.b25.fc21.x86_64'
+          :ensure =>'java-1.8.0-openjdk-1.8.0.40-24.b25.fc21.x86_64',
+          :name => 'java-1.8.0-openjdk',
         }
       )
       should contain_package('java-devel').with(
         {
-          :ensure =>'java-1.8.0-openjdk-devel-1.8.0.40-24.b25.fc21.x86_64'
+          :ensure =>'java-1.8.0-openjdk-devel-1.8.0.40-24.b25.fc21.x86_64',
+          :name => 'java-1.8.0-openjdk-devel',
         }
       )
     end
@@ -98,12 +104,14 @@ describe 'lightblue::java' do
     it do
       should contain_package('java').with(
         {
-          :ensure => 'latest'
+          :ensure => 'latest',
+          :name => 'java-1.7.0-openjdk',
         }
       )
       should contain_package('java-devel').with(
         {
-          :ensure => 'latest'
+          :ensure => 'latest',
+          :name => 'java-1.7.0-openjdk-devel',
         }
       )
     end
@@ -128,12 +136,14 @@ describe 'lightblue::java' do
     it do
       should contain_package('java').with(
         {
-          :ensure => 'latest'
+          :ensure => 'latest',
+          :name => 'java-1.8.0-openjdk',
         }
       )
       should contain_package('java-devel').with(
         {
-          :ensure => 'latest'
+          :ensure => 'latest',
+          :name => 'java-1.8.0-openjdk-devel',
         }
       )
     end
@@ -159,12 +169,14 @@ describe 'lightblue::java' do
     it do
       should contain_package('java').with(
         {
-          :ensure => 'java-1.8.0-openjdk-1.8.0.40-24.b25.fc21.x86_64'
+          :ensure => 'java-1.8.0-openjdk-1.8.0.40-24.b25.fc21.x86_64',
+          :name => 'java-1.8.0-openjdk',
         }
       )
       should contain_package('java-devel').with(
         {
-          :ensure =>'java-1.8.0-openjdk-devel-1.8.0.40-24.b25.fc21.x86_64'
+          :ensure =>'java-1.8.0-openjdk-devel-1.8.0.40-24.b25.fc21.x86_64',
+          :name => 'java-1.8.0-openjdk-devel',
         }
       )
     end


### PR DESCRIPTION
This fixes an issue where the java.pp class was not always working properly.

Changes
* defaults to latest
* adds ability to use installed or latest
* fixes ability to provide a java specific (possibly more accurately rpm specific) versioning