### PR TITLE
fixes #132 - sort arrays before using to ensure always the same

### DIFF
--- a/templates/application/migrator/lightblue-migrator-daemon.sh.erb
+++ b/templates/application/migrator/lightblue-migrator-daemon.sh.erb
@@ -54,7 +54,7 @@ do_exec()
   jsvcCommand << "$MAIN_CLASS"
 
   if @arguments
-    @arguments.each do |key, value|
+    @arguments.sort.each do |key, value|
       jsvcCommand << "--#{key}=#{value}"
     end
   end


### PR DESCRIPTION
sort will ensure the arguments are always sorted alphabetically. 