### PR TITLE
Fixing 'Invalid or misspelled module option: rolesProperties' warn

### DIFF
--- a/templates/lightblue-security-domain-cert.conf.erb
+++ b/templates/lightblue-security-domain-cert.conf.erb
@@ -12,7 +12,7 @@
                   "password-stacking" => "useFirstPass",
                   "securityDomain" => "lightblue-cert",
                   "verifier" => "org.jboss.security.auth.certs.AnyCertVerifier",
-                  "rolesProperties" => expression "file://${jboss.server.config.dir}/roles.properties",
+                  "rolesProperties" => "deleted",
                   "authRoleName" => "authenticated",
                   "ldapServer" => "<%= ldap_ad_server %>",
                   "searchBase" => "<%= ldap_search_base %>",


### PR DESCRIPTION
Deleting rolesProperties option in CertLdapLoginModule configuration. Requires jcliff-2.9.11 or higher. This will get rid of this warning in the server.log:
```
WARN  [org.jboss.security] PBOX000234: Invalid or misspelled module option: rolesProperties
```