### PR TITLE
Changing migrator service pid file location from /tmp to /var/run

### DIFF
--- a/spec/classes/lightblue/application/migrator/daemon_spec.rb
+++ b/spec/classes/lightblue/application/migrator/daemon_spec.rb
@@ -119,7 +119,7 @@ describe 'lightblue::application::migrator::daemon' do
           .without_content(/^JAVA_HOME_DIR=*$/) \
           .without_content(/^LIBS=*$/) \
           .with_content(/^MAIN_CLASS=#{main_class}$/) \
-          .with_content(/^PID=\/tmp\/#{service_name}.pid$/) \
+          .with_content(/^PID=\/var\/run\/#{service_name}.pid$/) \
           .with_content(/^LOG_OUT=#{log_out}$/) \
           .with_content(/^LOG_ERR=#{log_err}$/) \
           .with_content(/#{path_to_jar}/)

--- a/templates/application/migrator/lightblue-migrator-daemon.sh.erb
+++ b/templates/application/migrator/lightblue-migrator-daemon.sh.erb
@@ -16,7 +16,7 @@ LIBS=<%= lib_dir %>
 <% end -%>
 
 MAIN_CLASS=<%= mainClass %>
-PID=/tmp/<%= service_name %>.pid
+PID=/var/run/<%= service_name %>.pid
 
 LOG_OUT=<%= service_out_logfile %>
 LOG_ERR=<%= service_err_logfile %>


### PR DESCRIPTION
/etc/init.d/migrator-service restart can result in the service being started twice. This is because on rhel files older files are periodically removed from /tmp (see tmpwatch and /etc/cron.daily/tmpwatch),  /tmp/migrator-service.pid marker will be removed after the service runs for 10 days. Recommended location for pid files is /var/run.