### PR TITLE
Changed cacert to only apply when class param ca_apply is true (default behavior)

### DIFF
--- a/manifests/cacert.pp
+++ b/manifests/cacert.pp
@@ -13,21 +13,17 @@
 # [*ca_file*]
 #   File name for the ca cert.  Assumes does not include location.
 #
-#
-# [*ca_apply*]
-#   If true will attempt to deploy the cacert (default).  If false, the class does nothing.
-#
 # === Variables
 #
-# Module requires no global variables.
+# [*create_lightblue_cacert*]
+#   If true will attempt to deploy the cacert.  If false, the class does nothing.
 #
 class lightblue::cacert (
     $ca_source,
     $ca_location,
     $ca_file,
-    $ca_apply = true
 ) {
-    if $ca_apply {
+    if $::create_lightblue_cacert {
         file { $ca_location:
             ensure => directory,
             owner  => 'root',

--- a/manifests/cacert.pp
+++ b/manifests/cacert.pp
@@ -13,6 +13,10 @@
 # [*ca_file*]
 #   File name for the ca cert.  Assumes does not include location.
 #
+#
+# [*ca_apply*]
+#   If true will attempt to deploy the cacert (default).  If false, the class does nothing.
+#
 # === Variables
 #
 # Module requires no global variables.
@@ -21,9 +25,9 @@ class lightblue::cacert (
     $ca_source,
     $ca_location,
     $ca_file,
+    $ca_apply = true
 ) {
-    # not perfect, but if this file is already defined don't do it again
-    if ! defined (File["${ca_location}/${ca_file}"]) {
+    if $ca_apply {
         file { $ca_location:
             ensure => directory,
             owner  => 'root',

--- a/manifests/cacert.pp
+++ b/manifests/cacert.pp
@@ -16,14 +16,16 @@
 # === Variables
 #
 # [*create_lightblue_cacert*]
-#   If true will attempt to deploy the cacert.  If false, the class does nothing.
+#   If true, deploy the cacert.
+#   If false, do nothing.
+#   If undef, treat as true and deploy the cacert.
 #
 class lightblue::cacert (
     $ca_source,
     $ca_location,
     $ca_file,
 ) {
-    if $::create_lightblue_cacert {
+    if $::create_lightblue_cacert==undef or $::create_lightblue_cacert {
         file { $ca_location:
             ensure => directory,
             owner  => 'root',


### PR DESCRIPTION
The change to check if the file already exists didn't work because the lightblue class was consistently applied first.