### PR TITLE
Fix problem with creation of individual client ca certificate files

### DIFF
--- a/manifests/eap/client.pp
+++ b/manifests/eap/client.pp
@@ -122,6 +122,14 @@ define lightblue::eap::client (
     }
 
     if $ssl_ca_certificates == undef {
+        file { "${module_path}/${ssl_ca_file_path}":
+            mode    => '0440',
+            owner   => 'jboss',
+            group   => 'jboss',
+            links   => 'follow',
+            source  => $ssl_ca_source,
+            require => File[$module_dirs],
+        }
         $ssl_ca_cert_files = {
             "${ssl_ca_file_path}" => {
                 source  => $ssl_ca_source,
@@ -129,17 +137,15 @@ define lightblue::eap::client (
         }
     } else {
         $ssl_ca_cert_files = $ssl_ca_certificates
+        $ssl_ca_cert_file_defaults = {
+            'module_path'   => $module_path,
+            'mode'          => '0440',
+            'owner'         => 'jboss',
+            'group'         => 'jboss',
+            'links'         => 'follow',
+        }
+        create_resources(lightblue::eap::client_ca_cert_file, $ssl_ca_cert_files, $ssl_ca_cert_file_defaults)
     }
-
-    $ssl_ca_cert_file_defaults = {
-        'module_path'   => $module_path,
-        'mode'          => '0440',
-        'owner'         => 'jboss',
-        'group'         => 'jboss',
-        'links'         => 'follow',
-    }
-
-    create_resources(lightblue::eap::client_ca_cert_file, $ssl_ca_cert_files, $ssl_ca_cert_file_defaults)
 
     if $use_cert_auth {
         if $auth_cert_content {


### PR DESCRIPTION
Make file creation for individual vs multiple ca certs completely separate to prevent duplicate declaration errors if the class is called multiple times with single ca certs with the same name