### PR TITLE
lock lint version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 group :test do
   gem "rake"
   gem "puppet", ENV['PUPPET_VERSION'] || '~> 3.7.3'
-  gem "puppet-lint"
+  gem "puppet-lint", '1.1.0'
   gem "rspec-puppet"
   gem "puppet-syntax"
   gem "puppetlabs_spec_helper"


### PR DESCRIPTION
Locks the lint version to 1.1.0 which allows lint to pass. This however reveals a bunch of tests that are failing, but that is a different issue.

This can be merged.