### PR TITLE
add wildcard to access_log file rotation

### DIFF
--- a/manifests/eap/access_log.pp
+++ b/manifests/eap/access_log.pp
@@ -9,7 +9,7 @@ class lightblue::eap::access_log (
         content => template('lightblue/web-access-log.conf.erb'),
     }
     logrotate::file { 'jboss-access-logs':
-        log     => '/var/log/jbossas/standalone/default-host/access_log',
+        log     => '/var/log/jbossas/standalone/default-host/access_log*',
         options => ['compress',
                     'copytruncate',
                     'daily',


### PR DESCRIPTION
This should fix our issue with access logs not being rotated. I have these changes deployed in a test environment and will monitor tomorrow to ensure that things updated as expected.