### PR TITLE
Adding mongo readPreference and writeConcern properties to client config

### DIFF
--- a/manifests/client/client_cert.pp
+++ b/manifests/client/client_cert.pp
@@ -44,6 +44,8 @@ define lightblue::client::client_cert (
     $links = 'follow',
     $notify = undef,
     $use_physical_file = false,
+    $mongo_write_concern = undef,
+    $mongo_read_preference = undef,
 ) {
 
     lightblue::client::cert_file{ "cert-${name}":
@@ -58,18 +60,20 @@ define lightblue::client::client_cert (
     }
 
     lightblue::client::configure{ "${file_path}/${name}.properties":
-        owner                      => $owner,
-        group                      => $group,
-        lbclient_metadata_uri      => $metadata_service_uri,
-        lbclient_data_uri          => $data_service_uri,
-        lbclient_use_cert_auth     => $use_cert_auth,
-        lbclient_cert_file_path    => $file,
-        lbclient_cert_password     => $password,
-        lbclient_cert_alias        => $name,
-        lbclient_ca_certificates   => $ca_certificates,
-        lbclient_use_physical_file => $use_physical_file,
-        base_file_path             => $file_path,
-        notify                     => $notify,
+        owner                          => $owner,
+        group                          => $group,
+        lbclient_metadata_uri          => $metadata_service_uri,
+        lbclient_data_uri              => $data_service_uri,
+        lbclient_use_cert_auth         => $use_cert_auth,
+        lbclient_cert_file_path        => $file,
+        lbclient_cert_password         => $password,
+        lbclient_cert_alias            => $name,
+        lbclient_ca_certificates       => $ca_certificates,
+        lbclient_use_physical_file     => $use_physical_file,
+        base_file_path                 => $file_path,
+        notify                         => $notify,
+        lbclient_mongo_write_concern   => $mongo_write_concern,
+        lbclient_mongo_read_preference => $mongo_read_preference,
     }
 
 }

--- a/manifests/client/configure.pp
+++ b/manifests/client/configure.pp
@@ -46,6 +46,8 @@ define lightblue::client::configure (
     $lbclient_cert_alias = undef,
     $lbclient_use_physical_file = false,
     $lbclient_ca_certificates = undef,
+    $lbclient_mongo_read_preference = undef,
+    $lbclient_mongo_write_concern = undef,
     $base_file_path = undef,
 ) {
 

--- a/manifests/eap/client.pp
+++ b/manifests/eap/client.pp
@@ -49,6 +49,10 @@
 #   If this is defined, the values for $ssl_ca_file_path and $ssl_ca_source will
 #   be ignored
 #
+# [*mongo_write_concern*]
+#
+# [*mongo_read_preference*]
+#
 # === Variables
 #
 # None
@@ -91,6 +95,8 @@ define lightblue::eap::client (
     $ssl_ca_source=undef,
     $ssl_ca_file_path='cacert.pem',
     $ssl_ca_certificates = undef,
+    $mongo_write_concern = undef,
+    $mongo_read_preference = undef,
     $modules_home_path = '/usr/share/jbossas/modules',
     $owner = 'jboss',
     $group = 'jboss',
@@ -188,16 +194,18 @@ define lightblue::eap::client (
     }
 
     lightblue::client::configure{ "${module_path}/lightblue-client.properties":
-        owner                    => $owner,
-        group                    => $group,
-        lbclient_metadata_uri    => $metadata_service_uri,
-        lbclient_data_uri        => $data_service_uri,
-        lbclient_use_cert_auth   => $use_cert_auth,
-        lbclient_ca_file_path    => $ssl_ca_file_path,
-        lbclient_cert_file_path  => $auth_cert_file_path,
-        lbclient_cert_password   => $auth_cert_password,
-        lbclient_cert_alias      => $auth_cert_alias,
-        lbclient_ca_certificates => $ssl_ca_cert_files,
-        require                  => File[$module_dirs],
+        owner                          => $owner,
+        group                          => $group,
+        lbclient_metadata_uri          => $metadata_service_uri,
+        lbclient_data_uri              => $data_service_uri,
+        lbclient_use_cert_auth         => $use_cert_auth,
+        lbclient_ca_file_path          => $ssl_ca_file_path,
+        lbclient_cert_file_path        => $auth_cert_file_path,
+        lbclient_cert_password         => $auth_cert_password,
+        lbclient_cert_alias            => $auth_cert_alias,
+        lbclient_ca_certificates       => $ssl_ca_cert_files,
+        lbclient_mongo_write_concern   => $mongo_write_concern,
+        lbclient_mongo_read_preference => $mongo_read_preference,
+        require                        => File[$module_dirs],
     }
 }

--- a/templates/client/lightblue-client.properties.erb
+++ b/templates/client/lightblue-client.properties.erb
@@ -13,3 +13,9 @@ certFilePath=<% if(@lbclient_use_physical_file == true) %>file://<% if(@base_fil
 certPassword=<%= @lbclient_cert_password %>
 certAlias=<%= @lbclient_cert_alias %>
 <% end -%>
+<% if @lbclient_mongo_write_concern and @lbclient_mongo_write_concern!='' -%>
+execution.mongo.writeConcern=<%= @lbclient_mongo_write_concern %>
+<% end -%>
+<% if @lbclient_mongo_read_preference and @lbclient_mongo_read_preference!='' -%>
+execution.mongo.readPreference=<%= @lbclient_mongo_read_preference %>
+<% end -%>


### PR DESCRIPTION
Tests are broken. No point creating more broken tests.