### PR TITLE
Allow lightblue::eap::mongossl to be used outside of lightblue module

### DIFF
--- a/manifests/eap/mongo_keystore_file.pp
+++ b/manifests/eap/mongo_keystore_file.pp
@@ -26,7 +26,7 @@ define lightblue::eap::mongo_keystore_file ($file, $source) {
     }
 
     #This will create the keystore at the target location
-    java_ks { "${name}:${lightblue::java::java_home}/jre/lib/security/cacerts" :
+    java_ks { "${name}:${lightblue::eap::mongossl::cacerts_path}" :
         ensure       => latest,
         certificate  => $file,
         password     => $lightblue::eap::mongossl::java_ks_password,

--- a/manifests/eap/mongossl.pp
+++ b/manifests/eap/mongossl.pp
@@ -1,6 +1,7 @@
 class lightblue::eap::mongossl (
     $java_ks_password,
-    $certificates = undef,
+    $certificates,
+    $cacerts_path = "${lightblue::java::java_home}/jre/lib/security/cacerts",
 ) {
     create_resources(lightblue::eap::mongo_keystore_file, $certificates)
 }


### PR DESCRIPTION
This is useful if you want to setup access to lightblue mongo on a host which is not a lightblue host (not managed by this module).

Don't know why this is part of eap and not java, but leaving it as is.